### PR TITLE
Update links to refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,14 @@
     <ul>
       <li><cite id="bib-smpte-standards-operation-manual">SMPTE Standards Operation Manual</cite>, v3.1
       <a>https://f.hubspotusercontent00.net/hubfs/5253154/SMPTE%20Standards%20OM%20v3.1.pdf</a></li>
+      <li><cite id="bib-iso-directives">ISO/IEC Directives</cite>        
+        <a>http://www.iso.org/directives</a></li>
+      <li><cite id="bib-iso-directives-part2">ISO/IEC Directives, Part 2</cite>, Principles and rules for the structure and drafting of ISO and IEC documents (Ninth edition, 2021) 
+        <a>https://www.iso.org/sites/directives/current/part2/index.xhtml</a></li>
+      <li><cite id="bib-smpte-ag-03">SMPTE AG-03</cite>, Normative References
+      <a>https://www.smpte.org/about/policies-and-governance</a></li>
+      <li><cite id="bib-iso-8601-2004">ISO 8601:2004</cite>, Data elements and interchange formats — Information interchange — Representation of dates and times
+        <a>https://www.iso.org/standard/40874.html</a></li>
     </ul>
 
   </section>
@@ -69,6 +77,9 @@
   <section id="sec-terms-and-definitions">
 
     <!-- Use the `ul` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `ul` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `ul` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
+    <ul id="terms-ext-defs" itemscope="itemscope" itemtype="http://smpte.org/standards/external-definitions">
+      <li><a itemprop="external" href="#bib-smpte-standards-operations-manual"></a></li>
+    </ul>
 
   </section>
   <!-- End of Terms and definitions -->
@@ -88,10 +99,10 @@
     <section id="sec-style-guidelines">
       <h3>Style Guidelines</h3>
       <p>
-        All Engineering Documents should follow the guidelines of the International Organization for Standardization (ISO) Directives with the following exceptions: In the event of a conflict, explicit provisions of <a href="#bib-smpte-standards-operation-manual"></a> and Administrative Guidelines shall prevail. Any variances from the ISO Directives shall be approved by the Director of Engineering or the Standards Vice President.
+        All Engineering Documents should follow the guidelines of the <a href="#bib-iso-directives"></a> with the following exceptions: In the event of a conflict, explicit provisions of <a href="#bib-smpte-standards-operation-manual"></a> and Administrative Guidelines shall prevail. Any variances from the <a href="#bib-iso-directives"></a> shall be approved by the Director of Engineering or the Standards Vice President.
       </p>
       <p>
-        Particular attention should be given to the following annexes of the ISO Directives, Part 2:
+        Particular attention should be given to the following annexes of the <a href="#bib-iso-directives-part2"></a>:
       </p>
       <ul>
         <li>
@@ -107,15 +118,12 @@
           Annex E, Drafting of the title of a document
         </li>
       </ul>
-      <p>
-        The ISO Directives are available at: <a>http://www.iso.org/directives</a>.
-      </p>
     </section>
     
     <section id="sec-smpte-templates">
       <h3>SMPTE Templates</h3>
       <p>
-        All new Engineering Documents shall use the appropriate, approved SMPTE template. (See Administrative Guideline <a href="https://www.smpte.org/2020-standard-policies-and-governance">AG-04</a> Engineering Document Templates.) This will ensure proper     revision management through and including final publication. Document templates can be found in the Standards Community document repository.
+        All new Engineering Documents shall use the appropriate, approved SMPTE template. (See <a href="#bib-smpte-ag-04"></a>.) This will ensure proper     revision management through and including final publication. Document templates can be found in the Standards Community document repository.
       </p>
     </section>
 
@@ -125,7 +133,7 @@
         A revision of an Engineering Document may use the original template if the resulting prose is identical to that resulting from use of the current template and the Standards Vice President or Director of Engineering agree to the use of the original publication template.
       </p>
       <p>
-        For a revision of an Engineering Document, the Project Group should start with the Publication Master, which usually can be obtained from SMPTE HQ. The Project Group may, at its discretion, recreate the original document, as published, if an editable master cannot be found. The Project Group is encouraged to follow the ISO Directives but is under no obligation to do so.
+        For a revision of an Engineering Document, the Project Group should start with the Publication Master, which usually can be obtained from SMPTE HQ. The Project Group may, at its discretion, recreate the original document, as published, if an editable master cannot be found. The Project Group is encouraged to follow the <a href="#bib-iso-directives"></a> but is under no obligation to do so.
       </p>
       <p>
         An Amendment shall use the current template.
@@ -183,13 +191,13 @@
         <dt>XML</dt>
         <dd>
           <p>
-            Any document conforming to W3C Extensible Markup Language (XML) 1.0 (Fifth Edition) or W3C Extensible Markup Language (XML) 1.1 (Second Edition) may be submitted.
+            Any document conforming to <a href="#bib-w3c-xml-10-5ed"></a> or <a href="#bib-w3c-xml-11-2ed"></a> may be submitted.
           </p>
           <p>
             The namespaces of all normative XML elements used in XML documents shall have a corresponding normative reference in the prose.
           </p>
           <p>
-            The file extension shall be ".xml", unless otherwise specified by the defining specification of the document or by an appropriate IANA media type
+            The file extension shall be ".xml", unless otherwise specified by the defining specification of the document or by an appropriate <a href="#bib-iana"></a> media type
             registration.
           </p>
           <p>
@@ -197,13 +205,13 @@
           </p>
           <ul>
             <li>
-              W3C XML Schema Part 1: Structures Second Edition (file extension: .xsd)
+              <a href="#bib-w3c-xsd-1-2e"></a> (file extension: .xsd)
             </li>
             <li>
-              W3C Web Services Description Language (WSDL) 1.1
+              <a href="#bib-w3c-wsdl-11"></a>
             </li>
             <li>
-              XML Metadata Interchange (XMI), any Formally Released Version (<a>http://www.omg.org/spec/XMI/</a>)
+              <a href="#bib-xmi"></a>, any Formally Released Version
             </li>
           </ul>
         </dd>
@@ -245,7 +253,7 @@
   <section id="sec-normative-language-forms">
     <h2>Normative Language Forms</h2>
     <p>
-      Normative information in a SMPTE Engineering Document may take the language form of prose, tables, figures, formal languages (e.g., mathematical formulae, BNF, XML, pseudo code), and other language forms. Mathematical formulae shall follow the definitions documented in ISO 80000-2 when possible. When ISO 80000-2 is not sufficient (e.g., BNF, XML Schema, etc.), a Normative Reference for the mathematical definitions used shall be provided. Such Normative Reference shall comply with the provisions of the <a href="#bib-smpte-standards-operation-manual"></a> and AG-03 Normative References.
+      Normative information in a SMPTE Engineering Document may take the language form of prose, tables, figures, formal languages (e.g., mathematical formulae, BNF, XML, pseudo code), and other language forms. Mathematical formulae shall follow the definitions documented in <a href="#bib-iso-80000-2"></a> when possible. When <a href="#bib-iso-80000-2"></a> is not sufficient (e.g., BNF, XML Schema, etc.), a Normative Reference for the mathematical definitions used shall be provided. Such Normative Reference shall comply with the provisions of the <a href="#bib-smpte-standards-operation-manual"></a> and <a href="#bib-smpte-ag-03"></a>.
     </p>
     <p>
       When language forms other than prose are present, the prose shall state whether the language is normative or informative. Normative provisions shall be enabled explicitly (e.g., "The dimensions of figure 1 shall be used."). The presence of non-prose information without prose conformance language shall be deemed informative.
@@ -255,7 +263,7 @@
   <section id="sec-dates">
     <h2>Dates</h2>
     <p>
-      In accordance with ISO 8601-2004, all dates shall be represented in the form <code>YYYY-MM-DD</code> as numeric digits (e.g. <code>2009-04-23</code> to indicate April 23, 2009).
+      In accordance with <a href="#bib-iso-8601-2004"></a>, all dates shall be represented in the form <code>YYYY-MM-DD</code> as numeric digits (e.g. <code>2009-04-23</code> to indicate April 23, 2009).
     </p>
   </section>
 
@@ -675,6 +683,29 @@
       Using the content and form of the appropriate Engineering Document packages is recommended.
     </p>
   </section>
+
+  <section id="sec-bibliography">
+  <ul>
+    <li><cite id="bib-smpte-ag-04">SMPTE AG-04</cite>, Engineering Document Templates
+      <a>https://www.smpte.org/about/policies-and-governance</a></li>
+    <li><cite id="bib-w3c-xml-10-5ed">W3C Extensible Markup Language (XML) 1.0 (Fifth Edition)</cite>
+      <a>https://www.w3.org/TR/2008/REC-xml-20081126/</a></li>
+    <li><cite id="bib-w3c-xml-11-2ed">W3C Extensible Markup Language (XML) 1.1 (Second Edition)</cite>
+      <a>https://www.w3.org/TR/2006/REC-xml11-20060816/</a></li>
+    <li><cite id="bib-iana">IANA</cite>
+      <a>https://www.iana.org/</a></li>
+    <li><cite id="bib-w3c-xsd-1-2e">W3C XML Schema Part 1: Structures Second Edition</cite>
+      <a>https://www.w3.org/TR/2004/REC-xmlschema-1-20041028/</a></li>
+    <li><cite id="bib-w3c-wsdl-11">W3C Web Services Description Language (WSDL) 1.1</cite>
+      <a>https://www.w3.org/TR/2001/NOTE-wsdl-20010315</a></li>
+    <li><cite id="bib-xmi">XML Metadata Interchange (XMI)</cite>
+      <a>http://www.omg.org/spec/XMI/</a></li>
+    <li><cite id="bib-iso-80000-2">ISO 80000-2:2019</cite>, Quantities and units — Part 2: Mathematics
+        <a>https://www.iso.org/standard/64973.html</a></li>
+
+  </ul>
+</section>
+
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -58,9 +58,8 @@
 
     <!-- Add `li` sub elements as needed in this section as needed for references. If no Normative references, remove the entire `ul` element. Pre text for this section is auto generated based on `ul` present or not. -->
     <ul>
-<<<<<<< HEAD
-      <li><cite id="bib-smpte-standards-operation-manual">SMPTE Standards Operation Manual</cite>, v3.1
-      <a>https://f.hubspotusercontent00.net/hubfs/5253154/SMPTE%20Standards%20OM%20v3.1.pdf</a></li>
+      <li><cite id="bib-smpte-standards-operations-manual">SMPTE Standards Operations Manual</cite>
+      <a>https://www.smpte.org/about/policies-and-governance</a></li>
       <li><cite id="bib-iso-directives">ISO/IEC Directives</cite>        
         <a>http://www.iso.org/directives</a></li>
       <li><cite id="bib-iso-directives-part2">ISO/IEC Directives, Part 2</cite>, Principles and rules for the structure and drafting of ISO and IEC documents (Ninth edition, 2021) 
@@ -69,10 +68,6 @@
       <a>https://www.smpte.org/about/policies-and-governance</a></li>
       <li><cite id="bib-iso-8601-2004">ISO 8601:2004</cite>, Data elements and interchange formats — Information interchange — Representation of dates and times
         <a>https://www.iso.org/standard/40874.html</a></li>
-=======
-      <li><cite id="bib-smpte-standards-operations-manual">SMPTE Standards Operations Manual</cite>
-      <a>https://www.smpte.org/about/policies-and-governance</a></li>
->>>>>>> main
     </ul>
 
   </section>
@@ -104,11 +99,7 @@
     <section id="sec-style-guidelines">
       <h3>Style Guidelines</h3>
       <p>
-<<<<<<< HEAD
         All Engineering Documents should follow the guidelines of the <a href="#bib-iso-directives"></a> with the following exceptions: In the event of a conflict, explicit provisions of <a href="#bib-smpte-standards-operation-manual"></a> and Administrative Guidelines shall prevail. Any variances from the <a href="#bib-iso-directives"></a> shall be approved by the Director of Engineering or the Standards Vice President.
-=======
-        All Engineering Documents should follow the guidelines of the International Organization for Standardization (ISO) Directives with the following exceptions: In the event of a conflict, explicit provisions of <a href="#bib-smpte-standards-operations-manual"></a> and Administrative Guidelines shall prevail. Any variances from the ISO Directives shall be approved by the Director of Engineering or the Standards Vice President.
->>>>>>> main
       </p>
       <p>
         Particular attention should be given to the following annexes of the <a href="#bib-iso-directives-part2"></a>:
@@ -262,11 +253,7 @@
   <section id="sec-normative-language-forms">
     <h2>Normative Language Forms</h2>
     <p>
-<<<<<<< HEAD
       Normative information in a SMPTE Engineering Document may take the language form of prose, tables, figures, formal languages (e.g., mathematical formulae, BNF, XML, pseudo code), and other language forms. Mathematical formulae shall follow the definitions documented in <a href="#bib-iso-80000-2"></a> when possible. When <a href="#bib-iso-80000-2"></a> is not sufficient (e.g., BNF, XML Schema, etc.), a Normative Reference for the mathematical definitions used shall be provided. Such Normative Reference shall comply with the provisions of the <a href="#bib-smpte-standards-operation-manual"></a> and <a href="#bib-smpte-ag-03"></a>.
-=======
-      Normative information in a SMPTE Engineering Document may take the language form of prose, tables, figures, formal languages (e.g., mathematical formulae, BNF, XML, pseudo code), and other language forms. Mathematical formulae shall follow the definitions documented in ISO 80000-2 when possible. When ISO 80000-2 is not sufficient (e.g., BNF, XML Schema, etc.), a Normative Reference for the mathematical definitions used shall be provided. Such Normative Reference shall comply with the provisions of the <a href="#bib-smpte-standards-operations-manual"></a> and AG-03 Normative References.
->>>>>>> main
     </p>
     <p>
       When language forms other than prose are present, the prose shall state whether the language is normative or informative. Normative provisions shall be enabled explicitly (e.g., "The dimensions of figure 1 shall be used."). The presence of non-prose information without prose conformance language shall be deemed informative.


### PR DESCRIPTION
Link to norm and bib refs, add in OM to terms defined. Closes #4 

Note: I am aware there is a "broken" link to the OM from the term section, will resolve once merged with other PR in main branch. 